### PR TITLE
Fix some flake8 warnings and fix a Python typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Reductions for Fair Machine Learning
 
-A python package that implements the black-box approach to fair classification described in the paper [A Reductions Approach to Fair Classification](https://arxiv.org/abs/1803.02453).
+A Python package that implements the black-box approach to fair classification described in the paper [A Reductions Approach to Fair Classification](https://arxiv.org/abs/1803.02453).
 
 ## Installation
 

--- a/fairlearn/classred.py
+++ b/fairlearn/classred.py
@@ -115,7 +115,7 @@ class _Lagrangian:
                 print("%smul=%.0f" % (" "*9, mul))
             L_low_mul, tmp, tmp, tmp \
                 = self.eval(pd.Series({h_hat_idx: 1.0}), lambda_hat)
-            if (L_low_mul < res.L_low):
+            if L_low_mul < res.L_low:
                 res.L_low = L_low_mul
             if res.gap() > nu+_PRECISION:
                 break

--- a/fairlearn/classred.py
+++ b/fairlearn/classred.py
@@ -61,7 +61,7 @@ class _Lagrangian:
         self.n_oracle_calls = 0
         self.last_linprog_n_hs = 0
         self.last_linprog_result = None
-        
+
     def eval_from_error_gamma(self, error, gamma, lambda_vec):
         # Return the value of the Lagrangian.
         #
@@ -69,7 +69,7 @@ class _Lagrangian:
         #   L -- value of the Lagrangian
         #   L_high -- value of the Lagrangian under the best response of the
         #             lambda player
-        
+
         lambda_signed = lambda_vec["+"] - lambda_vec["-"]
         if self.opt_lambda:
             L = error + np.sum(lambda_vec*gamma) \
@@ -83,7 +83,7 @@ class _Lagrangian:
         else:
             L_high = error + self.B*(max_gamma-self.eps)
         return L, L_high
-    
+
     def eval(self, h, lambda_vec):
         # Return the value of the Lagrangian.
         #
@@ -93,7 +93,7 @@ class _Lagrangian:
         #             lambda player
         #   gamma -- vector of constraint violations
         #   error -- the empirical error
-        
+
         if callable(h):
             error = self.obj.gamma(h)[0]
             gamma = self.cons.gamma(h)
@@ -105,7 +105,7 @@ class _Lagrangian:
 
     def eval_gap(self, h, lambda_hat, nu):
         # Return the duality gap object for the given h and lambda_hat
-        
+
         L, L_high, gamma, error \
             = self.eval(h, lambda_hat)
         res = _GapResult(L, L, L_high, gamma, error)
@@ -120,7 +120,7 @@ class _Lagrangian:
             if res.gap() > nu+_PRECISION:
                 break
         return res
-    
+
     def solve_linprog(self, nu):
         n_hs = len(self.hs)
         n_cons = len(self.cons.index)
@@ -140,7 +140,7 @@ class _Lagrangian:
             (-A_ub.transpose(), A_eq.transpose()), axis=1)
         dual_b_ub = c
         dual_bounds = [
-            (None, None) if i==n_cons else (0, None) for i in range(n_cons+1)]
+            (None, None) if i == n_cons else (0, None) for i in range(n_cons+1)]
         res_dual = opt.linprog(dual_c, A_ub=dual_A_ub, b_ub=dual_b_ub,
                                bounds=dual_bounds)
         lambda_vec = pd.Series(res_dual.x[:-1], self.cons.index)
@@ -152,7 +152,7 @@ class _Lagrangian:
     def best_h(self, lambda_vec):
         # Return the classifier that solves the best-response problem
         # for the vector of Lagrange multipliers lambda_vec.
-    
+
         signed_weights = self.obj.signed_weights() \
                          + self.cons.signed_weights(lambda_vec)
         redY = 1*(signed_weights > 0)
@@ -162,14 +162,14 @@ class _Lagrangian:
         classifier = pickle.loads(self.pickled_learner)
         classifier.fit(self.X, redY, redW)
         self.n_oracle_calls += 1
-        
+
         h = lambda X: classifier.predict(X)
         h_error = self.obj.gamma(h)[0]
         h_gamma = self.cons.gamma(h)
         h_val = h_error + h_gamma.dot(lambda_vec)
 
         if not self.hs.empty:
-            vals =  self.errors + self.gammas.transpose().dot(lambda_vec)
+            vals = self.errors + self.gammas.transpose().dot(lambda_vec)
             best_idx = vals.idxmin()
             best_val = vals[best_idx]
         else:
@@ -191,7 +191,7 @@ class _Lagrangian:
 
 def _mean_pred(dataX, hs, weights):
     # Return a weighted average of predictions produced by classifiers in hs
-    
+
     pred = pd.DataFrame()
     for t in range(len(hs)):
         pred[t] = hs[t](dataX)
@@ -223,7 +223,7 @@ def expgrad(dataX, dataA, dataY, learner, cons=moments.DP(), eps=0.01,
     """
     Return a fair classifier under specified fairness constraints
     via exponentiated-gradient reduction.
-    
+
     Required input arguments:
       dataX -- a DataFrame containing covariates
       dataA -- a Series containing the protected attribute
@@ -265,9 +265,9 @@ def expgrad(dataX, dataA, dataY, learner, cons=moments.DP(), eps=0.01,
                                " last_t best_t n_oracle_calls")
 
     n = dataX.shape[0]
-    assert len(dataX.shape)==2 and len(dataA.shape)==1 and len(dataY.shape)==1, \
+    assert len(dataX.shape) == 2 and len(dataA.shape) == 1 and len(dataY.shape) == 1, \
         "dataX must be a DataFrame and dataY and dataA must be Series"
-    assert dataA.shape[0]==n and dataY.shape[0]==n, \
+    assert dataA.shape[0] == n and dataY.shape[0] == n, \
         "the number of rows in all data fields must match"
 
     if debug:
@@ -277,9 +277,9 @@ def expgrad(dataX, dataA, dataY, learner, cons=moments.DP(), eps=0.01,
     lagr = _Lagrangian(dataX, dataA, dataY, learner, cons, eps, B,
                        debug=debug)
 
-    theta  = pd.Series(0, lagr.cons.index)
+    theta = pd.Series(0, lagr.cons.index)
     Qsum = pd.Series()
-    lambdas  = pd.DataFrame()
+    lambdas = pd.DataFrame()
     gaps_EG = []
     gaps = []
     Qs = []
@@ -315,13 +315,13 @@ def expgrad(dataX, dataA, dataY, learner, cons=moments.DP(), eps=0.01,
         res_EG = lagr.eval_gap(Q_EG, lambda_EG, nu)
         gap_EG = res_EG.gap()
         gaps_EG.append(gap_EG)
-        
+
         if (t == 0) or not _RUN_LP_STEP:
             gap_LP = np.PINF
         else:
             Q_LP, lambda_LP, res_LP = lagr.solve_linprog(nu)
             gap_LP = res_LP.gap()
-            
+
         if gap_EG < gap_LP:
             Qs.append(Q_EG)
             gaps.append(gap_EG)
@@ -345,19 +345,19 @@ def expgrad(dataX, dataA, dataY, learner, cons=moments.DP(), eps=0.01,
                 eta *= _SHRINK_ETA
             last_regr_checked = t
             last_gap = best_gap
-            
+
         theta += eta*(gamma-eps)
-        
+
     last_t = len(Qs)-1
     gaps_series = pd.Series(gaps)
-    gaps_best = gaps_series[gaps_series<=gaps_series.min()+_PRECISION]
+    gaps_best = gaps_series[gaps_series <= gaps_series.min()+_PRECISION]
     best_t = gaps_best.index[-1]
     weights = Qs[best_t]
     hs = lagr.hs
     for h_idx in hs.index:
         if not weights.index.contains(h_idx):
             weights.at[h_idx] = 0.0
-    best_classifier = lambda X : _mean_pred(X, hs, weights)
+    best_classifier = lambda X: _mean_pred(X, hs, weights)
     best_gap = gaps[best_t]
 
     res = ExpgradResult(best_classifier=best_classifier,

--- a/fairlearn/moments.py
+++ b/fairlearn/moments.py
@@ -5,6 +5,7 @@ import pandas as pd
 
 __all__ = ["DP", "EO"]
 
+
 class Moment:
     """Generic moment"""
 
@@ -12,7 +13,7 @@ class Moment:
         self.initialized = False
 
     def init(self, dataX, dataA, dataY):
-        assert self.initialized==False, \
+        assert self.initialized is False, \
             "moments can be initialized only once"
         self.X = dataX
         self.tags = pd.DataFrame({"attr": dataA, "label": dataY})
@@ -55,7 +56,7 @@ class _CondOpportunity(Moment):
                            keys=["+", "-"],
                            names=["sign", "grp", "attr"])
         self.index = signed.index
-        
+
     def gamma(self, predictor):
         pred = predictor(self.X)
         self.tags["pred"] = pred
@@ -64,7 +65,7 @@ class _CondOpportunity(Moment):
         expect_attr_grp["diff"] = expect_attr_grp["pred"] - expect_grp["pred"]
         g_unsigned = expect_attr_grp["diff"]
         g_signed = pd.concat([g_unsigned, -g_unsigned],
-                             keys=["+","-"],
+                             keys=["+", "-"],
                              names=["sign", "grp", "attr"])
         self._gamma_descr = str(expect_attr_grp[["pred", "diff"]])
         return g_signed
@@ -77,20 +78,21 @@ class _CondOpportunity(Moment):
             lambda row: adjust[row["grp"], row["attr"]], axis=1
         )
         return signed_weights
-    
-    
+
+
 class DP(_CondOpportunity):
     """Demographic parity"""
     short_name = "DP"
 
     def init(self, dataX, dataA, dataY):
         super().init(dataX, dataA, dataY,
-                     dataY.apply(lambda y : "all"))
+                     dataY.apply(lambda y: "all"))
+
 
 class EO(_CondOpportunity):
     """Equalized odds"""
     short_name = "EO"
-    
+
     def init(self, dataX, dataA, dataY):
         super().init(dataX, dataA, dataY,
-                     dataY.apply(lambda y : "label="+str(y)))
+                     dataY.apply(lambda y: "label="+str(y)))

--- a/test_fairlearn.py
+++ b/test_fairlearn.py
@@ -12,10 +12,10 @@ import fairlearn.classred as red
 print = functools.partial(print, flush=True)
 
 
-class LeastSquaresLearner:    
+class LeastSquaresLearner:
     def __init__(self):
         self.weights = None
-        
+
     def fit(self, X, Y, W):
         sqrtW = np.sqrt(W)
         matX = np.array(X) * sqrtW[:, np.newaxis]
@@ -25,50 +25,53 @@ class LeastSquaresLearner:
 
     def predict(self, X):
         pred = X.dot(self.weights)
-        return 1*(pred>0.5)
+        return 1*(pred > 0.5)
 
 
-tests = [ {"cons_class": moments.DP, "eps": 0.100, "best_gap": 0.000000,
-           "last_t": 5, "best_t": 5, "disp": 0.100000, "error": 0.250000,
-           "n_oracle_calls":  32, "n_classifiers": 3},
-          {"cons_class": moments.DP, "eps": 0.050, "best_gap": 0.000000,
-           "last_t": 5, "best_t": 5, "disp": 0.050000,
-           "error": 0.266522, "n_oracle_calls":  23, "n_classifiers": 6},
-          {"cons_class": moments.DP, "eps": 0.020, "best_gap": 0.000000,
-           "last_t": 5, "best_t": 5, "disp": 0.020000, "error": 0.332261,
-           "n_oracle_calls":  22, "n_classifiers": 5},
-          {"cons_class": moments.DP, "eps": 0.010, "best_gap": 0.000000,
-           "last_t": 5, "best_t": 5, "disp": 0.010000, "error": 0.354174,
-           "n_oracle_calls":  22, "n_classifiers": 5},
-          {"cons_class": moments.DP, "eps": 0.005, "best_gap": 0.000000,
-           "last_t": 5, "best_t": 5, "disp": 0.005000, "error": 0.365130,
-           "n_oracle_calls":  22, "n_classifiers": 5},
-          {"cons_class": moments.EO, "eps": 0.100, "best_gap": 0.000000,
-           "last_t": 5, "best_t": 5, "disp": 0.100000, "error": 0.309333,
-           "n_oracle_calls":  21, "n_classifiers": 4},
-          {"cons_class": moments.EO, "eps": 0.050, "best_gap": 0.000000,
-           "last_t": 5, "best_t": 5, "disp": 0.050000, "error": 0.378827,
-           "n_oracle_calls":  19, "n_classifiers": 6},
-          {"cons_class": moments.EO, "eps": 0.020, "best_gap": 0.000000,
-           "last_t": 5, "best_t": 5, "disp": 0.020000, "error": 0.421531,
-           "n_oracle_calls":  19, "n_classifiers": 6},
-          {"cons_class": moments.EO, "eps": 0.010, "best_gap": 0.000000,
-           "last_t": 5, "best_t": 5, "disp": 0.010000, "error": 0.435765,
-           "n_oracle_calls":  19, "n_classifiers": 6},
-          {"cons_class": moments.EO, "eps": 0.005, "best_gap": 0.000000,
-           "last_t": 5, "best_t": 5, "disp": 0.005000, "error": 0.442883,
-           "n_oracle_calls":  19, "n_classifiers": 6},
-        ]
+tests = [{"cons_class": moments.DP, "eps": 0.100, "best_gap": 0.000000,
+          "last_t": 5, "best_t": 5, "disp": 0.100000, "error": 0.250000,
+          "n_oracle_calls":  32, "n_classifiers": 3},
+         {"cons_class": moments.DP, "eps": 0.050, "best_gap": 0.000000,
+          "last_t": 5, "best_t": 5, "disp": 0.050000,
+          "error": 0.266522, "n_oracle_calls":  23, "n_classifiers": 6},
+         {"cons_class": moments.DP, "eps": 0.020, "best_gap": 0.000000,
+          "last_t": 5, "best_t": 5, "disp": 0.020000, "error": 0.332261,
+          "n_oracle_calls":  22, "n_classifiers": 5},
+         {"cons_class": moments.DP, "eps": 0.010, "best_gap": 0.000000,
+          "last_t": 5, "best_t": 5, "disp": 0.010000, "error": 0.354174,
+          "n_oracle_calls":  22, "n_classifiers": 5},
+         {"cons_class": moments.DP, "eps": 0.005, "best_gap": 0.000000,
+          "last_t": 5, "best_t": 5, "disp": 0.005000, "error": 0.365130,
+          "n_oracle_calls":  22, "n_classifiers": 5},
+         {"cons_class": moments.EO, "eps": 0.100, "best_gap": 0.000000,
+          "last_t": 5, "best_t": 5, "disp": 0.100000, "error": 0.309333,
+          "n_oracle_calls":  21, "n_classifiers": 4},
+         {"cons_class": moments.EO, "eps": 0.050, "best_gap": 0.000000,
+          "last_t": 5, "best_t": 5, "disp": 0.050000, "error": 0.378827,
+          "n_oracle_calls":  19, "n_classifiers": 6},
+         {"cons_class": moments.EO, "eps": 0.020, "best_gap": 0.000000,
+          "last_t": 5, "best_t": 5, "disp": 0.020000, "error": 0.421531,
+          "n_oracle_calls":  19, "n_classifiers": 6},
+         {"cons_class": moments.EO, "eps": 0.010, "best_gap": 0.000000,
+          "last_t": 5, "best_t": 5, "disp": 0.010000, "error": 0.435765,
+          "n_oracle_calls":  19, "n_classifiers": 6},
+         {"cons_class": moments.EO, "eps": 0.005, "best_gap": 0.000000,
+          "last_t": 5, "best_t": 5, "disp": 0.005000, "error": 0.442883,
+          "n_oracle_calls":  19, "n_classifiers": 6},
+         ]
 
 _PRECISION = 1e-6
+
 
 def test_res_float(key, res, test, report_list):
     if abs(res[key]-test[key]) > _PRECISION:
         report_list.append("%s_diff=%e" % (key, res[key]-test[key]))
 
+
 def test_res_int(key, res, test, report_list):
     if abs(res[key]-test[key]) > 0:
-        report_list.append("%s_diff=%d" % (key, res[key]-test[key]))        
+        report_list.append("%s_diff=%d" % (key, res[key]-test[key]))
+
 
 if __name__ == '__main__':
     attrs = [str(x) for x in 'AAAAAAA' 'BBBBBBB' 'CCCCCC']
@@ -95,7 +98,7 @@ if __name__ == '__main__':
 
         error = moments.MisclassError()
         error.init(dataX, dataA, dataY)
-        
+
         res["disp"] = disp.gamma(Q).max()
         res["error"] = error.gamma(Q)[0]
         report_header = "testing (%s, eps=%.3f)" \


### PR DESCRIPTION
Plus remove redundant parentheses.

Tests pass before and after, with Python 3.7.0 on macOS High Sierra:

```console
$ python test_fairlearn.py
testing (DP, eps=0.100): ok
testing (DP, eps=0.050): ok
testing (DP, eps=0.020): ok
testing (DP, eps=0.010): ok
testing (DP, eps=0.005): ok
testing (EO, eps=0.100): ok
testing (EO, eps=0.050): ok
testing (EO, eps=0.020): ok
testing (EO, eps=0.010): ok
testing (EO, eps=0.005): ok
```
