### PR TITLE
updated to "key in index" from "contains" to suppress FutureWarning

### DIFF
--- a/fairlearn/classred.py
+++ b/fairlearn/classred.py
@@ -306,7 +306,7 @@ def expgrad(dataX, dataA, dataY, learner, cons=moments.DP(), eps=0.01,
                 print("...eps=%.3f, B=%.1f, nu=%.6f, T=%d, eta_min=%.6f"
                       % (eps, B, nu, T, eta_min))
 
-        if not Qsum.index.contains(h_idx):
+        if not h_idx in Qsum.index:
             Qsum.at[h_idx] = 0.0
         Qsum[h_idx] += 1.0
         gamma = lagr.gammas[h_idx]
@@ -355,7 +355,7 @@ def expgrad(dataX, dataA, dataY, learner, cons=moments.DP(), eps=0.01,
     weights = Qs[best_t]
     hs = lagr.hs
     for h_idx in hs.index:
-        if not weights.index.contains(h_idx):
+        if not h_idx in weights.index:
             weights.at[h_idx] = 0.0
     best_classifier = lambda X: _mean_pred(X, hs, weights)
     best_gap = gaps[best_t]


### PR DESCRIPTION
using FairLearn throws 2 FutureWarnings

```
fairlearn/classred.py:309: FutureWarning: The 'contains' method is deprecated and will be removed in a future version. Use 'key in index' instead of 'index.contains(key)'
```

```
fairlearn/classred.py:358: FutureWarning: The 'contains' method is deprecated and will be removed in a future version. Use 'key in index' instead of 'index.contains(key)'
```

This PR just implements the suggested changes