### PR TITLE
Argument Renaming

### DIFF
--- a/fairlearn/reductions/grid_search/grid_search.py
+++ b/fairlearn/reductions/grid_search/grid_search.py
@@ -68,15 +68,15 @@ class GridSearch(ReductionsLearner):
         else:
             raise RuntimeError("Can't get here")
 
-    def _fit_classification(self, X, Y, aux_data,
+    def _fit_classification(self, X, Y, protected_attribute,
                             lagrange_multipliers, number_of_lagrange_multipliers):
         # Verify we have a binary classification problem
         unique_labels = np.unique(Y)
         if not set(unique_labels).issubset({0, 1}):
             raise RuntimeError(self._MESSAGE_Y_NOT_BINARY)
 
-        # Extract required statistics from aux_data
-        p0, p1, a0_val = self._generate_aux_data_info(aux_data)
+        # Extract required statistics from protected_attribute
+        p0, p1, a0_val = self._generate_protected_attribute_info(protected_attribute)
 
         # If not supplied, generate array of trial lagrange multipliers
         if lagrange_multipliers is None:
@@ -91,7 +91,7 @@ class GridSearch(ReductionsLearner):
         for current_multiplier in lagrange_multipliers:
             # Generate weights array
             sample_weights = self._generate_classification_weights(Y,
-                                                                   aux_data,
+                                                                   protected_attribute,
                                                                    current_multiplier,
                                                                    p1 / p0,
                                                                    a0_val)
@@ -117,9 +117,9 @@ class GridSearch(ReductionsLearner):
         # Designate a 'best' model
         self.best_result = max(self.all_results, key=lambda x: x.quality_metric_value)
 
-    def _fit_regression(self, X, Y, aux_data, tradeoffs, number_of_tradeoffs):
-        # Extract required statistics from aux_data
-        p0, p1, a0_val = self._generate_aux_data_info(aux_data)
+    def _fit_regression(self, X, Y, protected_attribute, tradeoffs, number_of_tradeoffs):
+        # Extract required statistics from protected_attribute
+        p0, p1, a0_val = self._generate_protected_attribute_info(protected_attribute)
 
         if tradeoffs is None:
             tradeoffs = np.linspace(0, 1, number_of_tradeoffs)
@@ -127,7 +127,7 @@ class GridSearch(ReductionsLearner):
         self.all_results = []
         for tradeoff in tradeoffs:
             weight_func = np.vectorize(self._regression_weight_function)
-            weights = weight_func(aux_data,
+            weights = weight_func(protected_attribute,
                                   tradeoff,
                                   p0, p1, a0_val)
 
@@ -164,21 +164,21 @@ class GridSearch(ReductionsLearner):
         else:
             return 2 * y_val - 1 + L
 
-    def _generate_aux_data_info(self, aux_data):
+    def _generate_protected_attribute_info(self, protected_attribute):
         unique_labels, counts = np.unique(
-            aux_data, return_counts=True)
+            protected_attribute, return_counts=True)
         if len(unique_labels) > 2:
             raise RuntimeError("Protected Attribute contains "
                                "more than two unique values")
 
-        p0 = counts[0] / len(aux_data)
+        p0 = counts[0] / len(protected_attribute)
         p1 = 1 - p0
 
         return p0, p1, unique_labels[0]
 
-    def _generate_classification_weights(self, y, aux_data, L, p_ratio, a0_val):
+    def _generate_classification_weights(self, y, rotected_attribute, L, p_ratio, a0_val):
         weight_func = np.vectorize(self._classification_weight_function)
-        return weight_func(y, aux_data, L, p_ratio, a0_val)
+        return weight_func(y, rotected_attribute, L, p_ratio, a0_val)
 
     def _regression_weight_function(self, a_val, trade_off, p0, p1, a0_val):
         # Reweighting function for Bounded Group Loss for regression

--- a/fairlearn/reductions/grid_search/quality_metric.py
+++ b/fairlearn/reductions/grid_search/quality_metric.py
@@ -3,7 +3,7 @@
 
 
 class QualityMetric:
-    def set_data(self, X, Y, protected_attribute):
+    def set_data(self, X, Y, bin_id):
         raise NotImplementedError()
 
     def get_quality(self, model):

--- a/fairlearn/reductions/grid_search/simple_quality_metrics.py
+++ b/fairlearn/reductions/grid_search/simple_quality_metrics.py
@@ -20,13 +20,13 @@ class SimpleClassificationQualityMetric(QualityMetric):
         self.error_metric = moments.MisclassificationError()
         self.disparity_metric = moments.DP()
 
-    def set_data(self, X, Y, protected_attribute):
+    def set_data(self, X, Y, bin_id):
         self.X = X
         self.Y = Y
-        self.protected_attribute = protected_attribute
+        self.bin_id = bin_id
 
-        self.error_metric.init(X, protected_attribute, pd.Series(Y))
-        self.disparity_metric.init(X, protected_attribute, pd.Series(Y))
+        self.error_metric.init(X, bin_id, pd.Series(Y))
+        self.disparity_metric.init(X, bin_id, pd.Series(Y))
 
     def get_quality(self, model):
         current_error_metric = copy.deepcopy(self.error_metric)
@@ -45,15 +45,15 @@ class SimpleRegressionQualityMetric(QualityMetric):
     predict methods
     """
 
-    def set_data(self, X, Y, protected_attribute):
+    def set_data(self, X, Y, bin_id):
         self.X = X
         self.Y = Y
-        self.protected_attribute = protected_attribute
+        self.bin_id = bin_id
 
     def get_quality(self, model):
         labels = pd.Series(self.Y)
         preds = pd.Series(model.predict(self.X))
-        attrs = pd.Series(self.protected_attribute)
+        attrs = pd.Series(self.bin_id)
         attr_vals = attrs.unique()
         errors = (preds-labels)**2
         error = errors.mean()

--- a/notebooks/Grid Search for Binary Classification.ipynb
+++ b/notebooks/Grid Search for Binary Classification.ipynb
@@ -63,7 +63,7 @@
     "    Y = np.concatenate((Y_a0, Y_a1), axis=None)\n",
     "\n",
     "    X = pd.DataFrame({\"credit_score_feature\": score_feature,\n",
-    "                      \"protected_attribute_feature\": A})\n",
+    "                      \"aux_data_feature\": A})\n",
     "    return X, Y, A"
    ]
   },
@@ -107,11 +107,11 @@
    "source": [
     "import matplotlib.pyplot as plt\n",
     "def plot_data(Xs, Ys):\n",
-    "    labels = np.unique(Xs[\"protected_attribute_feature\"])\n",
+    "    labels = np.unique(Xs[\"aux_data_feature\"])\n",
     "    \n",
     "    for l in labels:\n",
     "        label_string = str(l.item())\n",
-    "        mask = Xs[\"protected_attribute_feature\"] == l\n",
+    "        mask = Xs[\"aux_data_feature\"] == l\n",
     "        plt.scatter(Xs[mask].credit_score_feature, Ys[mask], label=str(\"Label=\"+label_string))\n",
     "        plt.xlabel(\"Credit Score\")\n",
     "        plt.ylabel(\"Got Loan\")\n",
@@ -140,7 +140,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For this notebook, we use a simple binary classifier from `sklearn`. We can train this model on our biased data, and look at the weights the model places on each feature. The fact that the `protected_attribute_feature` has non-zero weight (the second entry in the `coef_` array) tells us that we have a biased model (note that measuring fairness in this way is only valid for this simple example notebook - in the real world, fairness is more complicated)."
+    "For this notebook, we use a simple binary classifier from `sklearn`. We can train this model on our biased data, and look at the weights the model places on each feature. The fact that the `aux_data_feature` has non-zero weight (the second entry in the `coef_` array) tells us that we have a biased model (note that measuring fairness in this way is only valid for this simple example notebook - in the real world, fairness is more complicated)."
    ]
   },
   {
@@ -195,7 +195,7 @@
     "                       disparity_metric=DemographicParity(),\n",
     "                       quality_metric=SimpleClassificationQualityMetric())\n",
     "\n",
-    "first_sweep.fit(X, Y, protected_attribute=A, number_of_lagrange_multipliers=11)"
+    "first_sweep.fit(X, Y, aux_data=A, number_of_lagrange_multipliers=11)"
    ]
   },
   {
@@ -228,9 +228,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "first_sweep_protected_attribute_weights = [\n",
+    "first_sweep_aux_data_weights = [\n",
     "            x.model.coef_[0][1] for x in first_sweep.all_results]\n",
-    "plt.scatter(lagrange_multipliers, first_sweep_protected_attribute_weights)\n",
+    "plt.scatter(lagrange_multipliers, first_sweep_aux_data_weights)\n",
     "plt.xlabel(\"Lagrange Multiplier\")\n",
     "plt.ylabel(\"Weight of Protected Attribute in Model\")\n",
     "plt.show()"
@@ -290,7 +290,7 @@
     "                        disparity_metric=DemographicParity(),\n",
     "                        quality_metric=SimpleClassificationQualityMetric())\n",
     "\n",
-    "second_sweep.fit(X, Y, protected_attribute=A, lagrange_multipliers=second_sweep_multipliers)"
+    "second_sweep.fit(X, Y, aux_data=A, lagrange_multipliers=second_sweep_multipliers)"
    ]
   },
   {
@@ -306,10 +306,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "second_sweep_protected_attribute_weights = [\n",
+    "second_sweep_aux_data_weights = [\n",
     "            x.model.coef_[0][1] for x in second_sweep.all_results]\n",
     "second_sweep_lagrange_multipliers = [x.lagrange_multiplier for x in second_sweep.all_results]\n",
-    "plt.scatter(second_sweep_lagrange_multipliers, second_sweep_protected_attribute_weights)\n",
+    "plt.scatter(second_sweep_lagrange_multipliers, second_sweep_aux_data_weights)\n",
     "plt.xlabel(\"Lagrange Multiplier\")\n",
     "plt.ylabel(\"Weight of Protected Attribute in Model\")\n",
     "plt.show()\n"

--- a/notebooks/Grid Search with Census Data.ipynb
+++ b/notebooks/Grid Search with Census Data.ipynb
@@ -206,7 +206,7 @@
    "outputs": [],
    "source": [
     "sweep.fit(X_train, Y_train,\n",
-    "          protected_attribute=A_train,\n",
+    "          aux_data=A_train,\n",
     "          number_of_lagrange_multipliers=71)\n",
     "\n",
     "models = [ z.model for z in sweep.all_results]"

--- a/test/reductions/grid_search/test_grid_search_classification.py
+++ b/test/reductions/grid_search/test_grid_search_classification.py
@@ -29,7 +29,7 @@ def _simple_threshold_data(number_a0, number_a1,
     Y = np.concatenate((Y_a0, Y_a1), axis=None)
 
     X = pd.DataFrame({"actual_feature": score_feature,
-                      "protected_attribute_feature": A,
+                      "aux_data_feature": A,
                       "constant_ones_feature": np.ones(len(Y))})
     return X, Y, A
 
@@ -55,12 +55,12 @@ def test_demographicparity_fair_uneven_populations():
                         disparity_metric=DemographicParity(),
                         quality_metric=SimpleClassificationQualityMetric())
 
-    target.fit(X, Y, protected_attribute=A,
+    target.fit(X, Y, aux_data=A,
                number_of_lagrange_multipliers=11)
     assert len(target.all_results) == 11
 
     test_X = pd.DataFrame({"actual_feature": [0.2, 0.7],
-                           "protected_attribute_feature": [a0_label, a1_label],
+                           "aux_data_feature": [a0_label, a1_label],
                            "constant_ones_feature": [1, 1]})
 
     sample_results = target.predict(test_X)

--- a/test/reductions/grid_search/test_grid_search_regression.py
+++ b/test/reductions/grid_search/test_grid_search_regression.py
@@ -30,7 +30,7 @@ def _simple_regression_data(number_a0, number_a1,
     Y = np.concatenate((Y_a0, Y_a1), axis=None)
 
     X = pd.DataFrame({"actual_feature": score_feature,
-                      "protected_attribute_feature": A,
+                      "aux_data_feature": A,
                       "constant_ones_feature": np.ones(len(Y))})
     return X, Y, A
 
@@ -53,12 +53,12 @@ def test_bgl_unfair():
                         disparity_metric=BoundedGroupLoss(),
                         quality_metric=SimpleRegressionQualityMetric())
 
-    target.fit(X, Y, protected_attribute=A, number_of_lagrange_multipliers=7)
+    target.fit(X, Y, aux_data=A, number_of_lagrange_multipliers=7)
 
     assert len(target.all_results) == 7
 
     test_X = pd.DataFrame({"actual_feature": [0.2, 0.7],
-                           "protected_attribute_feature": [a0_label, a1_label],
+                           "aux_data_feature": [a0_label, a1_label],
                            "constant_ones_feature": [1, 1]})
 
     best_predict = target.predict(test_X)
@@ -93,7 +93,7 @@ def test_bgl_unfair_compare():
                         disparity_metric=BoundedGroupLoss(),
                         quality_metric=SimpleRegressionQualityMetric())
 
-    target.fit(X, Y, protected_attribute=A, number_of_lagrange_multipliers=7)
+    target.fit(X, Y, aux_data=A, number_of_lagrange_multipliers=7)
 
     new_models = [z.model for z in target.all_results]
 


### PR DESCRIPTION
Some argument renaming for GridSearch
- kwarg `protected_attribute` becomes `aux_data` in `GridSearch`
- For quality metrics, replace `protected_attribute` with `bin_id`