### PR TITLE
Turn off code coverage for PR and CI

### DIFF
--- a/azuredevops/code-coverage.yml
+++ b/azuredevops/code-coverage.yml
@@ -1,8 +1,6 @@
-trigger:
-  branches:
-    include:
-    - master
-    - dev
+trigger: none
+
+pr: none
 
 schedules:
 - cron: "0 5 * * *" # Time is UTC


### PR DESCRIPTION
We don't need to run code coverage for every PR or merge