### PR TITLE
Remove obsolete `GridSearch` code

### DIFF
--- a/fairlearn/metrics/__init__.py
+++ b/fairlearn/metrics/__init__.py
@@ -3,11 +3,6 @@
 
 import sklearn.metrics as skm
 
-from .metric import DisparityMetric   # noqa: F401
-from .demographic_parity import DemographicParity  # noqa: F401
-from .equalized_odds import EqualizedOdds  # noqa: F401
-from .bounded_group_loss import BoundedGroupLoss  # noqa: F401
-
 from .group_metric_result import GroupMetricResult  # noqa: F401
 from .metrics_engine import metric_by_group, make_group_metric  # noqa: F401
 

--- a/fairlearn/metrics/bounded_group_loss.py
+++ b/fairlearn/metrics/bounded_group_loss.py
@@ -1,9 +1,0 @@
-# Copyright (c) Microsoft Corporation. All rights reserved.
-# Licensed under the MIT License.
-
-
-from .metric import DisparityMetric
-
-
-class BoundedGroupLoss(DisparityMetric):
-    pass

--- a/fairlearn/metrics/demographic_parity.py
+++ b/fairlearn/metrics/demographic_parity.py
@@ -1,9 +1,0 @@
-# Copyright (c) Microsoft Corporation. All rights reserved.
-# Licensed under the MIT License.
-
-
-from .metric import DisparityMetric
-
-
-class DemographicParity(DisparityMetric):
-    pass

--- a/fairlearn/metrics/equalized_odds.py
+++ b/fairlearn/metrics/equalized_odds.py
@@ -1,9 +1,0 @@
-# Copyright (c) Microsoft Corporation. All rights reserved.
-# Licensed under the MIT License.
-
-
-from .metric import DisparityMetric
-
-
-class EqualizedOdds(DisparityMetric):
-    pass

--- a/fairlearn/metrics/metric.py
+++ b/fairlearn/metrics/metric.py
@@ -1,6 +1,0 @@
-# Copyright (c) Microsoft Corporation. All rights reserved.
-# Licensed under the MIT License.
-
-
-class DisparityMetric:
-    pass

--- a/fairlearn/reductions/grid_search/grid_search.py
+++ b/fairlearn/reductions/grid_search/grid_search.py
@@ -5,7 +5,6 @@ import copy
 import numpy as np
 import pandas as pd
 
-from fairlearn.metrics import DemographicParity, BoundedGroupLoss
 from fairlearn.reductions.reductions_estimator import ReductionsEstimator
 from fairlearn.reductions.grid_search import QualityMetric, GridSearchResult
 from fairlearn.reductions.moments.moment import Moment, _REDUCTION_TYPE_CLASSIFICATION
@@ -82,16 +81,11 @@ class GridSearch(ReductionsEstimator):
     loss (for regression)
     """
 
-    _KW_LAGRANGE_MULTIPLIERS = "lagrange_multipliers"
-    _KW_NUMBER_LAGRANGE_MULTIPLIERS = "number_of_lagrange_multipliers"
-
     _MESSAGE_Y_NOT_BINARY = "Supplied y labels are not 0 or 1"
     _MESSAGE_X_NONE = "Must supply X"
     _MESSAGE_Y_NONE = "Must supply y"
     _MESSAGE_X_Y_ROWS = "X and y must have same number of rows"
     _MESSAGE_X_A_ROWS = "X and the target attribute must have same number of rows"
-
-    _FLIP_ATTRIBUTE_VALS = False
 
     def __init__(self,
                  learner,
@@ -101,9 +95,7 @@ class GridSearch(ReductionsEstimator):
                  grid_limit=2.0,
                  grid=None):
         self.learner = learner
-        if (not isinstance(disparity_metric, DemographicParity) and
-                not isinstance(disparity_metric, BoundedGroupLoss) and
-                not isinstance(disparity_metric, Moment)):
+        if not isinstance(disparity_metric, Moment):
             raise RuntimeError("Unsupported disparity metric")
         self.disparity_metric = disparity_metric
 
@@ -125,14 +117,6 @@ class GridSearch(ReductionsEstimator):
         if aux_data is None:
             raise RuntimeError("Must specify aux_data (for now)")
 
-        lagrange_multipliers = None
-        if self._KW_LAGRANGE_MULTIPLIERS in kwargs:
-            lagrange_multipliers = kwargs[self._KW_LAGRANGE_MULTIPLIERS]
-
-        number_of_lagrange_multipliers = None
-        if self._KW_NUMBER_LAGRANGE_MULTIPLIERS in kwargs:
-            number_of_lagrange_multipliers = kwargs[self._KW_NUMBER_LAGRANGE_MULTIPLIERS]
-
         # Extract the target attribute
         A = self._make_vector(aux_data, "aux_data")
 
@@ -153,149 +137,60 @@ class GridSearch(ReductionsEstimator):
         # Prep the quality metric
         self.quality_metric.set_data(X, y_vector, A)
 
-        if isinstance(self.disparity_metric, Moment):
-            if isinstance(self.disparity_metric, ConditionalOpportunity):
-                # We have a classification problem
-                # Need to make sure that y is binary (for now)
-                unique_labels = np.unique(y_vector)
-                if not set(unique_labels).issubset({0, 1}):
-                    raise RuntimeError(self._MESSAGE_Y_NOT_BINARY)
+        if isinstance(self.disparity_metric, ConditionalOpportunity):
+            # We have a classification problem
+            # Need to make sure that y is binary (for now)
+            unique_labels = np.unique(y_vector)
+            if not set(unique_labels).issubset({0, 1}):
+                raise RuntimeError(self._MESSAGE_Y_NOT_BINARY)
 
-            # Prep the disparity metric and objective
-            self.disparity_metric.init(X, A, y_vector)
-            objective = self.disparity_metric.default_objective()
-            objective.init(X, A, y_vector)
-            is_classification_reduction = (self.disparity_metric.reduction_type == _REDUCTION_TYPE_CLASSIFICATION)  # noqa: E501
+        # Prep the disparity metric and objective
+        self.disparity_metric.init(X, A, y_vector)
+        objective = self.disparity_metric.default_objective()
+        objective.init(X, A, y_vector)
+        is_classification_reduction = (self.disparity_metric.reduction_type == _REDUCTION_TYPE_CLASSIFICATION)  # noqa: E501
 
-            # Basis information
-            pos_basis = self.disparity_metric.pos_basis
-            neg_basis = self.disparity_metric.neg_basis
-            neg_allowed = self.disparity_metric.neg_basis_present
-            objective_in_the_span = (self.disparity_metric.default_objective_lambda_vec is not None)   # noqa: E501
+        # Basis information
+        pos_basis = self.disparity_metric.pos_basis
+        neg_basis = self.disparity_metric.neg_basis
+        neg_allowed = self.disparity_metric.neg_basis_present
+        objective_in_the_span = (self.disparity_metric.default_objective_lambda_vec is not None)   # noqa: E501
 
-            if self.grid is None:
-                grid = _GridGenerator(self.grid_size,
-                                      self.grid_limit,
-                                      pos_basis,
-                                      neg_basis,
-                                      neg_allowed,
-                                      objective_in_the_span).grid
-            else:
-                grid = self.grid
-
-            # Fit the estimates
-            self.all_results = []
-            for i in grid.columns:
-                lambda_vec = grid[i]
-                weights = self.disparity_metric.signed_weights(lambda_vec)
-                if not objective_in_the_span:
-                    weights = weights + objective.signed_weights()
-                if is_classification_reduction:
-                    y_reduction = 1 * (weights > 0)
-                    weights = weights.abs()
-                else:
-                    y_reduction = y_vector
-
-                current_learner = copy.deepcopy(self.learner)
-                current_learner.fit(X, y_reduction, sample_weight=weights)
-
-                # Evaluate the quality metric
-                quality = self.quality_metric.get_quality(current_learner)
-
-                nxt = GridSearchResult(current_learner, lambda_vec, quality)
-                self.all_results.append(nxt)
-
-            # Designate a 'best' model
-            self.best_result = max(self.all_results, key=lambda x: x.quality_metric_value)
-            return
-
-        # We do not yet have disparity metrics fully implemented
-        # For now, we assume that if we are passed a DemographicParity
-        # object we have a binary classification problem whereas
-        # BoundedGroupLoss indicates a regression
-        if isinstance(self.disparity_metric, DemographicParity):
-            self._fit_classification(X, y_vector, A,
-                                     lagrange_multipliers, number_of_lagrange_multipliers)
-        elif isinstance(self.disparity_metric, BoundedGroupLoss):
-            self._fit_regression(X, y_vector, A,
-                                 lagrange_multipliers, number_of_lagrange_multipliers)
+        if self.grid is None:
+            grid = _GridGenerator(self.grid_size,
+                                  self.grid_limit,
+                                  pos_basis,
+                                  neg_basis,
+                                  neg_allowed,
+                                  objective_in_the_span).grid
         else:
-            raise RuntimeError("Can't get here")
+            grid = self.grid
 
-    def _fit_classification(self, X, y, target_attribute,
-                            lagrange_multipliers, number_of_lagrange_multipliers):
-        # Verify we have a binary classification problem
-        unique_labels = np.unique(y)
-        if not set(unique_labels).issubset({0, 1}):
-            raise RuntimeError(self._MESSAGE_Y_NOT_BINARY)
-
-        # Extract required statistics from target_attribute
-        p0, p1, a0_val = self._generate_target_attribute_info(target_attribute)
-
-        # If not supplied, generate array of trial lagrange multipliers
-        if lagrange_multipliers is None:
-            limit = 1
-            if p1 > 0 and p0 / p1 > 1:
-                limit = p0 / p1
-            lagrange_multipliers = np.linspace(-2 * limit,
-                                               2 * limit,
-                                               number_of_lagrange_multipliers)
-
+        # Fit the estimates
         self.all_results = []
-        for current_multiplier in lagrange_multipliers:
-            # Generate weights array
-            sample_weights = self._generate_classification_weights(y,
-                                                                   target_attribute,
-                                                                   current_multiplier,
-                                                                   p1 / p0,
-                                                                   a0_val)
+        for i in grid.columns:
+            lambda_vec = grid[i]
+            weights = self.disparity_metric.signed_weights(lambda_vec)
+            if not objective_in_the_span:
+                weights = weights + objective.signed_weights()
+            if is_classification_reduction:
+                y_reduction = 1 * (weights > 0)
+                weights = weights.abs()
+            else:
+                y_reduction = y_vector
 
-            # Generate y'
-            def f(x): return 1 if x > 0 else 0
-            re_labels = np.vectorize(f)(sample_weights)
-
-            # Run the learner
             current_learner = copy.deepcopy(self.learner)
-            current_learner.fit(X, re_labels, sample_weight=np.absolute(sample_weights))
+            current_learner.fit(X, y_reduction, sample_weight=weights)
 
             # Evaluate the quality metric
             quality = self.quality_metric.get_quality(current_learner)
 
-            # Append the new model, along with its current_multiplier value
-            # to the result
-            # Note that we call it a model because it is a learner which has
-            # had 'fit' called
-            nxt = GridSearchResult(current_learner, current_multiplier, quality)
+            nxt = GridSearchResult(current_learner, lambda_vec, quality)
             self.all_results.append(nxt)
 
         # Designate a 'best' model
         self.best_result = max(self.all_results, key=lambda x: x.quality_metric_value)
-
-    def _fit_regression(self, X, y, target_attribute, tradeoffs, number_of_tradeoffs):
-        # Extract required statistics from target_attribute
-        p0, p1, a0_val = self._generate_target_attribute_info(target_attribute)
-
-        if tradeoffs is None:
-            tradeoffs = np.linspace(0, 1, number_of_tradeoffs)
-
-        self.all_results = []
-        for tradeoff in tradeoffs:
-            weight_func = np.vectorize(self._regression_weight_function)
-            weights = weight_func(target_attribute,
-                                  tradeoff,
-                                  p0, p1, a0_val)
-
-            current_learner = copy.deepcopy(self.learner)
-            current_learner.fit(X, y, sample_weight=weights)
-
-            # Evaluate the quality metric
-            quality = self.quality_metric.get_quality(current_learner)
-
-            nxt = GridSearchResult(current_learner, tradeoff, quality)
-            self.all_results.append(nxt)
-
-        # Designate a 'best' model
-        self.best_result = max(self.all_results, key=lambda x: x.quality_metric_value)
+        return
 
     def predict(self, X):
         return self.best_result.model.predict(X)
@@ -308,42 +203,6 @@ class GridSearch(ReductionsEstimator):
 
     def posterior_predict_proba(self, X):
         return [r.model.predict_proba(X) for r in self.all_results]
-
-    def _classification_weight_function(self, y_val, a_val, L, p_ratio, a0_val):
-        # Used by the classification side of GridSearch to generate a sample
-        # set of weights, following demographic parity
-        # Weights vary with the current value of the Lagrange multiplier
-        if a_val == a0_val:
-            return 2 * y_val - 1 - L * p_ratio
-        else:
-            return 2 * y_val - 1 + L
-
-    def _generate_target_attribute_info(self, target_attribute):
-        unique_labels, counts = np.unique(
-            target_attribute, return_counts=True)
-        if len(unique_labels) > 2:
-            raise RuntimeError("Target Attribute contains "
-                               "more than two unique values")
-
-        p0 = counts[0] / len(target_attribute)
-        p1 = 1 - p0
-
-        if self._FLIP_ATTRIBUTE_VALS:
-            return p1, p0, unique_labels[1]
-        else:
-            return p0, p1, unique_labels[0]
-
-    def _generate_classification_weights(self, y, target_attribute, L, p_ratio, a0_val):
-        weight_func = np.vectorize(self._classification_weight_function)
-        return weight_func(y, target_attribute, L, p_ratio, a0_val)
-
-    def _regression_weight_function(self, a_val, trade_off, p0, p1, a0_val):
-        # Reweighting function for Bounded Group Loss for regression
-        # Note that it uses a trade_off parameter which varies between 0 and 1
-        if a_val == a0_val:
-            return trade_off / p0
-        else:
-            return (1 - trade_off) / p1
 
     def _make_vector(self, formless, formless_name):
         formed_vector = None

--- a/notebooks/Grid Search for Binary Classification.ipynb
+++ b/notebooks/Grid Search for Binary Classification.ipynb
@@ -301,14 +301,42 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "l = first_sweep.best_result.lagrange_multiplier\n",
-    "second_sweep_multipliers = np.linspace(l-0.5, l+0.5, 31)\n",
+    "second_sweep_multipliers = np.linspace(lambda_best-0.5, lambda_best+0.5, 31)\n",
     "\n",
+    "iterables = [['+', '-'], ['all'], [a0_label, a1_label]]\n",
+    "midx = pd.MultiIndex.from_product(iterables, names=['sign', 'grp', 'group_id'])\n",
+    "\n",
+    "second_sweep_lambdas = []\n",
+    "for l in second_sweep_multipliers:\n",
+    "    nxt = pd.Series(np.zeros(4), index=midx)\n",
+    "    if l < 0:\n",
+    "        nxt[(\"-\", \"all\", 2)] = abs(l)\n",
+    "    else:\n",
+    "        nxt[(\"+\", \"all\", 2)] = l\n",
+    "    second_sweep_lambdas.append(nxt)\n",
+    "    \n",
+    "multiplier_df = pd.concat(second_sweep_lambdas,axis=1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And we can use these multipliers in another sweep:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "second_sweep=GridSearch(LogisticRegression(solver='liblinear', fit_intercept=True),\n",
     "                        disparity_metric=DemographicParity(),\n",
-    "                        quality_metric=SimpleClassificationQualityMetric())\n",
+    "                        quality_metric=SimpleClassificationQualityMetric(),\n",
+    "                        grid=multiplier_df)\n",
     "\n",
-    "second_sweep.fit(X, Y, aux_data=A, lagrange_multipliers=second_sweep_multipliers)"
+    "second_sweep.fit(X, Y, aux_data=A)"
    ]
   },
   {
@@ -326,8 +354,7 @@
    "source": [
     "second_sweep_aux_data_weights = [\n",
     "            x.model.coef_[0][1] for x in second_sweep.all_results]\n",
-    "second_sweep_lagrange_multipliers = [x.lagrange_multiplier for x in second_sweep.all_results]\n",
-    "plt.scatter(second_sweep_lagrange_multipliers, second_sweep_aux_data_weights)\n",
+    "plt.scatter(second_sweep_multipliers, second_sweep_aux_data_weights)\n",
     "plt.xlabel(\"Lagrange Multiplier\")\n",
     "plt.ylabel(\"Weight of Protected Attribute in Model\")\n",
     "plt.show()\n"
@@ -346,7 +373,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(\"lambda_best =\",second_sweep.best_result.lagrange_multiplier)\n",
+    "lambda_best_second = second_sweep.best_result.lagrange_multiplier[(\"+\", \"all\", 2)] \\\n",
+    "                     -second_sweep.best_result.lagrange_multiplier[(\"-\", \"all\", 2)]\n",
+    "print(\"lambda_best =\",lambda_best_second)\n",
     "print(\"coefficients =\",second_sweep.best_result.model.coef_)"
    ]
   },

--- a/notebooks/Grid Search for Binary Classification.ipynb
+++ b/notebooks/Grid Search for Binary Classification.ipynb
@@ -19,9 +19,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from fairlearn.metrics import DemographicParity\n",
     "from fairlearn.reductions import GridSearch\n",
     "from fairlearn.reductions.grid_search.simple_quality_metrics import SimpleClassificationQualityMetric\n",
+    "from fairlearn.reductions.moments import DemographicParity\n",
     "\n",
     "import numpy as np\n",
     "import pandas as pd\n",
@@ -192,7 +192,7 @@
     "                       disparity_metric=DemographicParity(),\n",
     "                       quality_metric=SimpleClassificationQualityMetric())\n",
     "\n",
-    "first_sweep.fit(X, Y, aux_data=A, number_of_lagrange_multipliers=11)"
+    "first_sweep.fit(X, Y, aux_data=A)"
    ]
   },
   {
@@ -208,8 +208,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "lagrange_multipliers = [x.lagrange_multiplier for x in (first_sweep.all_results)]\n",
-    "lagrange_multipliers"
+    "lagrange_multipliers = [x.lagrange_multiplier.iat[0] - x.lagrange_multiplier.iat[2] for x in (first_sweep.all_results)]\n",
+    "lagrange_multipliers\n",
+    "first_sweep.best_result.lagrange_multiplier#[(\"+\", \"all\", 2)]"
    ]
   },
   {

--- a/notebooks/Grid Search for Binary Classification.ipynb
+++ b/notebooks/Grid Search for Binary Classification.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Grid Search for Binary Classification\n",
     "\n",
-    "This notebook goes through applying the `GridSearch` algorithm in FairLearn to a binary classification problem, where we also have a binary protected attribute.\n",
+    "This notebook goes through applying the `GridSearch` algorithm in FairLearn to a binary classification problem, where we also have a binary protected attribute. This algorithm comes from the paper [\"A Reductions Approach to Fair Classification\" (Agarwal et al. 2018)](https://arxiv.org/abs/1803.02453). The grid search is a simplified version of the full algorithm (appearing in section 3.4), which works best for binary classification and a binary protected attribute.\n",
     "\n",
     "The specific problem we consider a biased credit scoring problem. We assume that we have a collection of individuals characterised by two features - a credit score in the range $[0, 1]$ and a binary protected attribute from ${a_0, a_1}$. We also have a binary 'score' for each individual indicating whether or not they got a loan. This is determined by applying a threshold to their credit score, and to make the dataset unfair, we can set different thresholds for the two groups $a_0$ and $a_1$.\n",
     "\n",
@@ -179,7 +179,7 @@
     "\n",
     "The grid search acts like a normal `sklearn` estimator, implementing `fit()` and `predict()` methods. The `fit()` method performs the grid search, and the best model found (according to the supplied quality metric) is used in `predict()` calls. However, after `fit()` is called, there are two extra properties on the estimator - a `best_result` and a list `all_results`; the `best_result` is used by `predict()` while `all_results` corresponds to the output of the grid search itself. The items in each are dictionaries, each with three entries - `lagrange_multiplier`, `quality_metric` and `model`.\n",
     "\n",
-    "We start by telling the algorithm that we want to try 11 different values of $\\lambda$ (which are generated for us)."
+    "We start by telling the algorithm that we want to try 7 different values of $\\lambda$ (which are generated for us)."
    ]
   },
   {
@@ -190,7 +190,8 @@
    "source": [
     "first_sweep=GridSearch(LogisticRegression(solver='liblinear', fit_intercept=True),\n",
     "                       disparity_metric=DemographicParity(),\n",
-    "                       quality_metric=SimpleClassificationQualityMetric())\n",
+    "                       quality_metric=SimpleClassificationQualityMetric(),\n",
+    "                      grid_size=7)\n",
     "\n",
     "first_sweep.fit(X, Y, aux_data=A)"
    ]
@@ -208,9 +209,27 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "lagrange_multipliers = [x.lagrange_multiplier.iat[0] - x.lagrange_multiplier.iat[2] for x in (first_sweep.all_results)]\n",
-    "lagrange_multipliers\n",
-    "first_sweep.best_result.lagrange_multiplier#[(\"+\", \"all\", 2)]"
+    "lagrange_multipliers = [x.lagrange_multiplier for x in (first_sweep.all_results)]\n",
+    "lagrange_multipliers[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is rather more than a single value $\\lambda$, so what's going on? These results are the outputs of the `Moment` type which drives the reduction approach to removing disparity. There are actually four Lagrange multipliers here, indexed by a tuple (sign, grp, group_id). The 'group_id' field corresponds to the labels $a_0$ and $a_1$, while the 'grp' field is the same in all cases (this is because we have specified Demographic Parity as our disparity criterion). Finally the 'sign' comes from the reductions approach specifying separate multipliers for violations of the disparity criterion from above and below. Both of these are constrained to be positive.\n",
+    "\n",
+    "So we have four multipliers - $\\lambda_{(+,2)}$, $\\lambda_{(-,2)}$, $\\lambda_{(+,3)}$ and $\\lambda_{(-,3)}$. Without losing generality, we can decide to modify one of these, but not the other, and the `DemographicParity` object we passed to the `GridSearch` constructor chose to make $\\lambda_{(+,3)}=\\lambda_{(-,3)}=0$. Finally, we can combine the 'above' and 'below' multipliers for the other group and obtain $\\lambda_i = \\lambda_{(+,2)} - \\lambda_{(-,2)}$:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "actual_multipliers = [x[(\"+\", \"all\", 2)]-x[(\"-\", \"all\", 2)] for x in lagrange_multipliers]\n",
+    "actual_multipliers"
    ]
   },
   {
@@ -228,7 +247,7 @@
    "source": [
     "first_sweep_aux_data_weights = [\n",
     "            x.model.coef_[0][1] for x in first_sweep.all_results]\n",
-    "plt.scatter(lagrange_multipliers, first_sweep_aux_data_weights)\n",
+    "plt.scatter(actual_multipliers, first_sweep_aux_data_weights)\n",
     "plt.xlabel(\"Lagrange Multiplier\")\n",
     "plt.ylabel(\"Weight of Protected Attribute in Model\")\n",
     "plt.show()"
@@ -247,7 +266,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(\"lambda_best =\",first_sweep.best_result.lagrange_multiplier)\n",
+    "lambda_best = first_sweep.best_result.lagrange_multiplier[(\"+\", \"all\", 2)]-first_sweep.best_result.lagrange_multiplier[(\"-\", \"all\", 2)]\n",
+    "print(\"lambda_best =\",lambda_best)\n",
     "print(\"coefficients =\",first_sweep.best_result.model.coef_)"
    ]
   },

--- a/notebooks/Grid Search with Census Data.ipynb
+++ b/notebooks/Grid Search with Census Data.ipynb
@@ -205,8 +205,7 @@
     "sweep.fit(X_train, Y_train,\n",
     "          aux_data=A_train)\n",
     "\n",
-    "models = [ z.model for z in sweep.all_results]\n",
-    "len(models)"
+    "models = [ z.model for z in sweep.all_results]"
    ]
   },
   {

--- a/notebooks/Grid Search with Census Data.ipynb
+++ b/notebooks/Grid Search with Census Data.ipynb
@@ -28,7 +28,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from fairlearn.metrics import DemographicParity\n",
     "from fairlearn.reductions import GridSearch\n",
     "from fairlearn.reductions.grid_search.simple_quality_metrics import SimpleClassificationQualityMetric\n",
     "from fairlearn.reductions import moments\n",
@@ -183,8 +182,9 @@
    "outputs": [],
    "source": [
     "sweep = GridSearch(LogisticRegression(solver='liblinear', fit_intercept=True),\n",
-    "                   disparity_metric=DemographicParity(),\n",
-    "                   quality_metric=SimpleClassificationQualityMetric())"
+    "                   disparity_metric=moments.DemographicParity(),\n",
+    "                   quality_metric=SimpleClassificationQualityMetric(),\n",
+    "                   grid_size=71)"
    ]
   },
   {
@@ -203,10 +203,10 @@
    "outputs": [],
    "source": [
     "sweep.fit(X_train, Y_train,\n",
-    "          aux_data=A_train,\n",
-    "          number_of_lagrange_multipliers=71)\n",
+    "          aux_data=A_train)\n",
     "\n",
-    "models = [ z.model for z in sweep.all_results]"
+    "models = [ z.model for z in sweep.all_results]\n",
+    "len(models)"
    ]
   },
   {


### PR DESCRIPTION
With the `Moment`-based implementation of `GridSearch` in, remove obsolete code:
- Handwritten reweighting/relabelling in `GridSearch`
- Portions of `metrics` such as `metrics.DemographicParity` which are just used as `enum`s